### PR TITLE
Create major and minor releases

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs: # https://stackoverflow.com/questions/59175332/using-output-from-a-previous-job-in-a-new-one-in-a-github-action
       Version: ${{ steps.gitversion.outputs.SemVer }}
+      Major: ${{ steps.gitversion.outputs.Major }}
+      Minor: ${{ steps.gitversion.outputs.Minor }}
       CommitsSinceVersionSource: ${{ steps.gitversion.outputs.CommitsSinceVersionSource }}  
     steps:    
       - uses: actions/checkout@v4
@@ -86,3 +88,19 @@ jobs:
         tag: "v${{ needs.build.outputs.Version }}"
         name: "v${{ needs.build.outputs.Version }}"
         token: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+    - name: Create Major version Release (update) #Create or Update the major version release. e.g. 'v2'
+      uses: ncipollo/release-action@v1
+      if: needs.build.outputs.CommitsSinceVersionSource > 0 
+      with:
+        tag: "v${{ needs.build.outputs.Major }}"
+        name: "v${{ needs.build.outputs.Major }}"
+        allowUpdates: true
+        token: ${{ secrets.GITHUB_TOKEN }} 
+    - name: Create Minor version Release (update) #Create or Update the minor version release. e.g. 'v2.1'
+      uses: ncipollo/release-action@v1
+      if: needs.build.outputs.CommitsSinceVersionSource > 0 
+      with:
+        tag: "v${{ needs.build.outputs.Major }}.${{ needs.build.outputs.Minor }}"
+        name: "v${{ needs.build.outputs.Major }}.${{ needs.build.outputs.Minor }}"
+        allowUpdates: true
+        token: ${{ secrets.GITHUB_TOKEN }} #

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -44,7 +44,7 @@ jobs:
         uses: ./ # the ./ runs the action.yml in this repo 
         with:
           projects: 'Sample\ConsoleApp1\ConsoleApp1.csproj'
-          dotnet-version: '7.0.x'
+          dotnet-version: '8.0.x'
           sonarcloud-organization: samsmithnz-github
           sonarcloud-project: samsmithnz_SamsDotNetSonarCloudAction
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
@@ -62,7 +62,7 @@ jobs:
         uses: ./ # the ./ runs the action.yml in this repo 
         with:
           projects: 'Sample/ConsoleApp1/ConsoleApp1.csproj'
-          dotnet-version: '7.0.x'
+          dotnet-version: '8.0.x'
           sonarcloud-organization: samsmithnz-github
           sonarcloud-project: samsmithnz_SamsDotNetSonarCloudAction
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
This pull request primarily updates the GitHub Actions workflow file `.github/workflows/CI.yml`. The changes include adding new outputs for Major and Minor versions, updating the dotnet version used in the workflow, and adding steps to create or update Major and Minor version releases.

Changes to GitHub Actions workflow:

* [`.github/workflows/CI.yml`](diffhunk://#diff-3ab46ee209a127470fce3c2cf106b1a1dbadbb929a4b5b13656a4bc4ce19c0b8R15-R16): Added `Major` and `Minor` outputs to the workflow, allowing for more specific versioning.
* [`.github/workflows/CI.yml`](diffhunk://#diff-3ab46ee209a127470fce3c2cf106b1a1dbadbb929a4b5b13656a4bc4ce19c0b8L45-R47): Updated the `dotnet-version` used in the workflow from '7.0.x' to '8.0.x'. This change was applied in two places in the workflow. [[1]](diffhunk://#diff-3ab46ee209a127470fce3c2cf106b1a1dbadbb929a4b5b13656a4bc4ce19c0b8L45-R47) [[2]](diffhunk://#diff-3ab46ee209a127470fce3c2cf106b1a1dbadbb929a4b5b13656a4bc4ce19c0b8L63-R65)
* [`.github/workflows/CI.yml`](diffhunk://#diff-3ab46ee209a127470fce3c2cf106b1a1dbadbb929a4b5b13656a4bc4ce19c0b8R91-R106): Added steps to create or update Major and Minor version releases. These steps are conditional on there being commits since the version source. The release tags and names are derived from the `Major` and `Minor` outputs.