### PR TITLE
Update CI.yml

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,11 +21,11 @@ jobs:
           fetch-depth: 0 #fetch-depth is needed for GitVersion
           #Install and calculate the new version with GitVersion          
       - name: Install GitVersion
-        uses: gittools/actions/gitversion/setup@v0.10.2
+        uses: gittools/actions/gitversion/setup@v0.13.4
         with:
           versionSpec: 5.x
       - name: Determine Version
-        uses: gittools/actions/gitversion/execute@v0.10.2
+        uses: gittools/actions/gitversion/execute@v0.13.4
         id: gitversion # step id used as reference for output values
       - name: Display GitVersion outputs
         run: |


### PR DESCRIPTION
This pull request includes an update to the GitVersion tool in the Continuous Integration (CI) workflow. The `CI.yml` file, which is part of the GitHub workflows, has been modified to use a newer version of GitVersion.

The key change is:

* [`.github/workflows/CI.yml`](diffhunk://#diff-3ab46ee209a127470fce3c2cf106b1a1dbadbb929a4b5b13656a4bc4ce19c0b8L24-R28): Updated the version of GitVersion being used in the CI workflow from `v0.10.2` to `v0.13.4`. This change affects both the setup and execution steps of GitVersion in the workflow.